### PR TITLE
Set Minimum PyTorch Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch
+torch>=2.3
 transformers
 datasets
 pydantic


### PR DESCRIPTION
Fixes #76 

Set the minimum PyTorch version in the `requirements.txt` that is required for the library.